### PR TITLE
Site settings, editables and form layout updates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
         tasks: ["wiredep"]
       },
       js: {
-        files: ["<%= gonevisDash.app %>/{,*/}*.js"],
+        files: ["<%= gonevisDash.app %>/{,*/*/}*.js"],
         tasks: ["newer:jshint:all", "newer:jscs:all"],
         options: {
           livereload: "<%= connect.options.livereload %>"

--- a/app/account/user/user_view.html
+++ b/app/account/user/user_view.html
@@ -24,8 +24,8 @@
         </div>
       </div>
       <div class="panel-footer">
-        <a ui-sref="dash.change-password">
-          <button type="button" class="btn btn-danger">Change Password</button>
+        <a ui-sref="dash.change-password" class="btn btn-danger btn-sm">
+          <i class="fa fa-lock fa-fw"></i> Change Password
         </a>
       </div>
     </div>

--- a/app/account/user/user_view.html
+++ b/app/account/user/user_view.html
@@ -7,7 +7,7 @@
             <div class="avatar avatar-outside" style="margin-top: -94px">{{ user.name[0] }}</div>
           </div>
           <div class="col-md-8">
-            <h3 class="text-right o-fade-soft" editable-text="user.name" onbeforesave="updateProfile('name', $data)">{{ user.name }}</h3>
+            <h3 class="text-right o-fade-soft" editable-text="user.name" onbeforesave="updateProfile('name', $data)">{{ user.name || "You have no name :-[" }}</h3>
           </div>
         </div>
         <div class="s-mar-top">

--- a/app/account/user/user_view.html
+++ b/app/account/user/user_view.html
@@ -18,7 +18,7 @@
           </div>
           <div class="panel panel-default panel-body s-mar-no">
             <i class="fa fa-border text-info s-mar-right-soft fa-map-marker"></i>
-            <span editable-text="user.location" onbeforesave="updateProfile('location', $data)">{{ user.location }}</span>
+            <span editable-text="user.location" onbeforesave="updateProfile('location', $data)">{{ user.location || "Nothing here..." }}</span>
             <small class="o-fade pull-right">LOCATION</small>
           </div>
         </div>

--- a/app/account/user/user_view.html
+++ b/app/account/user/user_view.html
@@ -12,12 +12,10 @@
         </div>
         <div class="s-mar-top">
           <div class="panel panel-default panel-body">
-            <i class="fa fa-border text-info s-mar-right-soft fa-user"></i>
             <span editable-textarea="user.about" onbeforesave="updateProfile('about', $data)">{{ user.about || "Nothing here..." }}</span>
             <small class="o-fade pull-right">ABOUT</small>
           </div>
           <div class="panel panel-default panel-body s-mar-no">
-            <i class="fa fa-border text-info s-mar-right-soft fa-map-marker"></i>
             <span editable-text="user.location" onbeforesave="updateProfile('location', $data)">{{ user.location || "Nothing here..." }}</span>
             <small class="o-fade pull-right">LOCATION</small>
           </div>

--- a/app/account/user/user_view.html
+++ b/app/account/user/user_view.html
@@ -13,7 +13,7 @@
         <div class="s-mar-top">
           <div class="panel panel-default panel-body">
             <i class="fa fa-border text-info s-mar-right-soft fa-user"></i>
-            <span editable-textarea="user.about" onbeforesave="updateProfile('about', $data)">{{ user.about }}</span>
+            <span editable-textarea="user.about" onbeforesave="updateProfile('about', $data)">{{ user.about || "Nothing here..." }}</span>
             <small class="o-fade pull-right">ABOUT</small>
           </div>
           <div class="panel panel-default panel-body s-mar-no">

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -566,7 +566,7 @@ tags-input .tags.focused {
 /* Editable */
 
 .editable-hide {
-  display: block !important;
+  display: initial !important;
 }
 
 .editable-wrap {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -566,7 +566,7 @@ tags-input .tags.focused {
 /* Editable */
 
 .editable-hide {
-  display: initial !important;
+  display: block !important;
 }
 
 .editable-wrap {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -14,8 +14,10 @@ h6 {
   margin: 0;
 }
 
-a {
+a,
+button {
   cursor: pointer;
+  outline: 0 !important;
 }
 
 .nav,
@@ -347,10 +349,10 @@ md-toast {
 
 /* Editing Mode + Text Angular */
 
-
 .ta-toolbar .btn-group {
   margin-bottom: 4px;
 }
+
 .editing-mode .ta-toolbar .btn-group {
   margin-bottom: 4px;
   margin-top: 4px;
@@ -558,4 +560,47 @@ tags-input .tags.focused {
   width: 350px;
   margin-left: 318px;
   margin-bottom: 10px;
+}
+
+
+/* Editable */
+
+.editable-hide {
+  display: initial !important;
+}
+
+.editable-wrap {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1000;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 5% 20%;
+}
+
+.editable-input {
+  width: 100% !important;
+}
+
+.editable-controls {
+  width: 100% !important;
+}
+
+.editable-buttons {
+  display: block;
+  width: 100% !important;
+  margin-top: 10px;
+}
+
+.editable-buttons .btn {
+  padding: 10px 30px;
+  margin: 0;
+  margin-right: 10px;
+}
+
+.editable-input {
+  font-size: large;
+  padding: 30px;
 }

--- a/app/site/site_settings/site_settings_controller.js
+++ b/app/site/site_settings/site_settings_controller.js
@@ -12,8 +12,9 @@
  * @param API
  * @param ModalsService
  * @param AuthService
+ * @param DolphinService
  */
-function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, ModalsService, AuthService) {
+function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, ModalsService, AuthService, DolphinService) {
 
   var site = AuthService.getCurrentSite()
 
@@ -25,13 +26,11 @@ function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, Modal
    */
   function constructor() {
     $scope.user = AuthService.getAuthenticatedUser();
+    $scope.dolphinService = DolphinService;
 
     API.Site.get({ site_id: site },
       function (data, status, headers, config) {
         $scope.sietSettings = data;
-      },
-      function (data, status, headers, config) {
-        console.log(data);
       }
     );
   };
@@ -106,5 +105,6 @@ SiteSettingsController.$inject = [
   '$mdToast',
   'API',
   'ModalsService',
-  'AuthService'
+  'AuthService',
+  'DolphinService'
 ];

--- a/app/site/site_settings/site_settings_controller.js
+++ b/app/site/site_settings/site_settings_controller.js
@@ -92,7 +92,12 @@ function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, Modal
         $mdToast.showSimple("Sorry we couldn't delete the site, please try again later");
       }
     );
-  }
+  };
+
+  $scope.$on("gonevisDash.DolphinService:select", function (data, dolphin) {
+    $scope.siteSettings.cover_image = dolphin.id;
+    $scope.updateSite("cover_image", dolphin.id);
+  });
 
   constructor();
 }

--- a/app/site/site_settings/site_settings_controller.js
+++ b/app/site/site_settings/site_settings_controller.js
@@ -52,7 +52,7 @@ function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, Modal
 
     API.SiteUpdate.put({ site_id: site }, payload,
       function (data, status, headers, config) {
-        $scope.siteDetail = data;
+        $scope.sietSettings[key] = data[key];
         $mdToast.showSimple("Profile update.");
       },
       function (data, status, headers, config) {

--- a/app/site/site_settings/site_settings_controller.js
+++ b/app/site/site_settings/site_settings_controller.js
@@ -30,7 +30,7 @@ function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, Modal
 
     API.Site.get({ site_id: site },
       function (data, status, headers, config) {
-        $scope.sietSettings = data;
+        $scope.siteSettings = data;
       }
     );
   };
@@ -51,7 +51,7 @@ function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, Modal
 
     API.SiteUpdate.put({ site_id: site }, payload,
       function (data, status, headers, config) {
-        $scope.sietSettings[key] = data[key];
+        $scope.siteSettings[key] = data[key];
         $mdToast.showSimple("Profile update.");
       },
       function (data, status, headers, config) {

--- a/app/site/site_settings/site_settings_controller.js
+++ b/app/site/site_settings/site_settings_controller.js
@@ -28,7 +28,7 @@ function SiteSettingsController($scope, $rootScope, $state, $mdToast, API, Modal
 
     API.Site.get({ site_id: site },
       function (data, status, headers, config) {
-        $scope.siteDetail = data;
+        $scope.sietSettings = data;
       },
       function (data, status, headers, config) {
         console.log(data);

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -34,6 +34,12 @@
           </span>
           <small class="o-fade pull-right">META TITLE</small>
         </div>
+        <!-- Meta Description -->
+        <div class="panel panel-default panel-body">
+          <span editable-textarea="siteSettings.meta_description" onbeforesave="updateSite('meta_description', $data)">
+            {{ siteSettings.meta_description || "Nothing here..." }}
+          </span>
+          <small class="o-fade pull-right">META DESCRIPTION</small>
         </div>
       </div>
       <div class="panel-footer">

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -4,19 +4,24 @@
       <div class="panel-body s-pad">
         <div class="row">
           <div class="col-md-12">
-            <h3 class="text-center o-fade-soft" editable-text="siteDetail.title" onbeforesave="updateSite('title', $data)">{{ siteDetail.title }}</h3>
+            <h2 class="o-fade-soft" editable-text="sietSettings.title"
+                onbeforesave="updateSite('title', $data)">{{ sietSettings.title }}</h2>
           </div>
         </div>
         <div class="s-mar-top">
           <div class="panel panel-default panel-body">
-            <i class="fa fa-border text-info s-mar-right-soft fa-user"></i>
-            <span editable-textarea="siteDetail.description" onbeforesave="updateSite('description', $data)">{{ siteDetail.description }}</span>
+            <i class="fa fa-border text-info s-mar-right-soft fa-info"></i>
+            <span editable-textarea="sietSettings.description" onbeforesave="updateSite('description', $data)">
+              {{ sietSettings.description }}
+            </span>
             <small class="o-fade pull-right">DESCRIPTION</small>
           </div>
         </div>
       </div>
       <div class="panel-footer">
-        <button class="btn btn-danger btn-sm" ng-click="remove(siteDetail.id)"><i class="fa fa-trash"></i> Delete Site</button>
+        <button class="btn btn-danger btn-sm" ng-click="remove(sietSettings.id)">
+          <i class="fa fa-trash"></i> Delete Site
+        </button>
       </div>
     </div>
   </div>

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -30,11 +30,6 @@
         </div>
       </div>
       <div class="panel-footer">
-        <!-- Image -->
-        <button class="btn btn-default btn-sm pull-right" ng-click="dolphinService.viewSelection()"
-                title="Set or Change cover image of site.">
-          <i class="fa fa-image"></i> Cover Image
-        </button>
         <!-- Delete -->
         <button class="btn btn-danger btn-sm" ng-click="remove(siteSettings.id)">
           <i class="fa fa-trash"></i> Delete Site

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -1,13 +1,24 @@
 <div class="container container-light">
   <div class="col-md-6 col-md-offset-3">
     <div class="panel panel-default s-box s-mar-top">
+      <div class="panel-heading">
+        <h3>
+          <!-- Title -->
+          {{ siteSettings.title }}
+          <!-- Image -->
+          <button class="btn btn-default btn-sm pull-right" ng-click="dolphinService.viewSelection()"
+                  title="Set or Change cover image of site.">
+            <i class="fa fa-image"></i> Cover Image
+          </button>
+        </h3>
+      </div>
       <div class="panel-body s-pad">
-        <div class="row">
-          <div class="col-md-12">
-            <!-- Title -->
-            <h2 class="o-fade-soft" editable-text="siteSettings.title"
-                onbeforesave="updateSite('title', $data)">{{ siteSettings.title }}</h2>
-          </div>
+        <!-- Title -->
+        <div class="panel panel-default panel-body">
+          <span editable-text="siteSettings.title" onbeforesave="updateSite('title', $data)">
+            {{ siteSettings.title || "Nothing here..." }}
+          </span>
+          <small class="o-fade pull-right">TITLE</small>
         </div>
         <div class="s-mar-top">
           <div class="panel panel-default panel-body">

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -27,6 +27,13 @@
           </span>
           <small class="o-fade pull-right">DESCRIPTION</small>
         </div>
+        <!-- Meta Title -->
+        <div class="panel panel-default panel-body">
+          <span editable-text="siteSettings.meta_title" onbeforesave="updateSite('meta_title', $data)">
+            {{ siteSettings.meta_title || "Nothing here..." }}
+          </span>
+          <small class="o-fade pull-right">META TITLE</small>
+        </div>
         </div>
       </div>
       <div class="panel-footer">

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -1,15 +1,17 @@
 <div class="container container-light">
   <div class="col-md-6 col-md-offset-3">
-    <div class="panel panel-default s-box" style="margin-top: 64px">
+    <div class="panel panel-default s-box s-mar-top">
       <div class="panel-body s-pad">
         <div class="row">
           <div class="col-md-12">
+            <!-- Title -->
             <h2 class="o-fade-soft" editable-text="sietSettings.title"
                 onbeforesave="updateSite('title', $data)">{{ sietSettings.title }}</h2>
           </div>
         </div>
         <div class="s-mar-top">
           <div class="panel panel-default panel-body">
+            <!-- Description -->
             <i class="fa fa-border text-info s-mar-right-soft fa-info"></i>
             <span editable-textarea="sietSettings.description" onbeforesave="updateSite('description', $data)">
               {{ sietSettings.description }}
@@ -19,6 +21,12 @@
         </div>
       </div>
       <div class="panel-footer">
+        <!-- Image -->
+        <button class="btn btn-default btn-sm pull-right" ng-click="dolphinService.viewSelection()"
+                title="Set or Change cover image of site.">
+          <i class="fa fa-image"></i> Cover Image
+        </button>
+        <!-- Delete -->
         <button class="btn btn-danger btn-sm" ng-click="remove(sietSettings.id)">
           <i class="fa fa-trash"></i> Delete Site
         </button>

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -20,15 +20,13 @@
           </span>
           <small class="o-fade pull-right">TITLE</small>
         </div>
-        <div class="s-mar-top">
-          <div class="panel panel-default panel-body">
-            <!-- Description -->
-            <i class="fa fa-border text-info s-mar-right-soft fa-info"></i>
-            <span editable-textarea="siteSettings.description" onbeforesave="updateSite('description', $data)">
-              {{ siteSettings.description }}
-            </span>
-            <small class="o-fade pull-right">DESCRIPTION</small>
-          </div>
+        <!-- Description -->
+        <div class="panel panel-default panel-body">
+          <span editable-textarea="siteSettings.description" onbeforesave="updateSite('description', $data)">
+            {{ siteSettings.description || "Nothing here..." }}
+          </span>
+          <small class="o-fade pull-right">DESCRIPTION</small>
+        </div>
         </div>
       </div>
       <div class="panel-footer">

--- a/app/site/site_settings/site_settings_view.html
+++ b/app/site/site_settings/site_settings_view.html
@@ -5,16 +5,16 @@
         <div class="row">
           <div class="col-md-12">
             <!-- Title -->
-            <h2 class="o-fade-soft" editable-text="sietSettings.title"
-                onbeforesave="updateSite('title', $data)">{{ sietSettings.title }}</h2>
+            <h2 class="o-fade-soft" editable-text="siteSettings.title"
+                onbeforesave="updateSite('title', $data)">{{ siteSettings.title }}</h2>
           </div>
         </div>
         <div class="s-mar-top">
           <div class="panel panel-default panel-body">
             <!-- Description -->
             <i class="fa fa-border text-info s-mar-right-soft fa-info"></i>
-            <span editable-textarea="sietSettings.description" onbeforesave="updateSite('description', $data)">
-              {{ sietSettings.description }}
+            <span editable-textarea="siteSettings.description" onbeforesave="updateSite('description', $data)">
+              {{ siteSettings.description }}
             </span>
             <small class="o-fade pull-right">DESCRIPTION</small>
           </div>
@@ -27,7 +27,7 @@
           <i class="fa fa-image"></i> Cover Image
         </button>
         <!-- Delete -->
-        <button class="btn btn-danger btn-sm" ng-click="remove(sietSettings.id)">
+        <button class="btn btn-danger btn-sm" ng-click="remove(siteSettings.id)">
           <i class="fa fa-trash"></i> Delete Site
         </button>
       </div>


### PR DESCRIPTION
# Site settings, editables and form layout updates
Fixes #94 #110 #114 #131 #130 

### Edtiables fixed desing
![image](https://cloud.githubusercontent.com/assets/4629328/18938867/d89a49f0-860c-11e6-8413-cfb72991139e.png)

### Settings layout + Cover image + Meta data support
![image](https://cloud.githubusercontent.com/assets/4629328/18938877/feaff374-860c-11e6-9155-deb80e37de86.png)

### Editables empty variables
![image](https://cloud.githubusercontent.com/assets/4629328/18938886/13598704-860d-11e6-9b49-385b87fa6689.png)

## Notes and usage
@ArsalanSavand: I need you to:
- Use default strings (see how I used) for editables.
- Not to use icons for editables.
- Not to set the entire variable when updating single key, only update that key of var.