### PR TITLE
Pagination feature

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -627,3 +627,15 @@ tags-input .tags.focused {
   font-size: large;
   padding: 30px;
 }
+
+
+/* Load more */
+
+.load-more .btn {
+  margin-bottom: 15px;
+}
+
+.load-more {
+  margin: 15px 0;
+  text-align: center;
+}

--- a/app/basement/pagination/pagination_loadmore.html
+++ b/app/basement/pagination/pagination_loadmore.html
@@ -1,0 +1,8 @@
+<div class="load-more">
+  <button class="btn btn-default btn-lg"
+          ng-if="!paginationForm.page.noMore"
+          ng-disabled="paginationForm.page.loading" 
+          ng-click="loadMore(paginationForm)">
+    {{ paginationForm.page.loading ? "LOADING" : "LOAD MORE" }}
+  </button>
+</div>

--- a/app/basement/pagination/pagination_service.js
+++ b/app/basement/pagination/pagination_service.js
@@ -11,6 +11,18 @@
  *
  * @returns [Factory]
  */
+  function paginate(form, data, payload) {
+    form.page = {
+      next: data.next,
+      prev: data.prev,
+      payload: payload,
+      loading: false,
+      noMore: true,
+    };
+    if (data.next) form.page.noMore = false;
+    return form;
+  }
+
 }
 
 app.factory("Pagination", Pagination);

--- a/app/basement/pagination/pagination_service.js
+++ b/app/basement/pagination/pagination_service.js
@@ -11,6 +11,7 @@
  *
  * @returns [Factory]
  */
+function Pagination($resource, $rootScope) {
 
   /**
    * paginate
@@ -56,6 +57,11 @@
     form.page.loading = true;
     return form;
   }
+
+  return {
+    paginate: paginate,
+    loadMore: loadMore
+  };
 }
 
 app.factory("Pagination", Pagination);

--- a/app/basement/pagination/pagination_service.js
+++ b/app/basement/pagination/pagination_service.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/**
+ * Pagination
+ *
+ * @class Pagination
+ * @namespace gonevisDash.Pagination
+ *
+ * @param $resource
+ * @param $rootScope
+ *
+ * @returns [Factory]
+ */
+}
+
+app.factory("Pagination", Pagination);
+Pagination.$inject = [
+  "$resource",
+  "$rootScope"
+];

--- a/app/basement/pagination/pagination_service.js
+++ b/app/basement/pagination/pagination_service.js
@@ -34,6 +34,14 @@
     return form;
   }
 
+  /**
+   * loadMore
+   *
+   * @method loadMore
+   * @desc Loadmore function based on pagination vars in form data
+   *
+   * @param form {Object} Form data for API
+   */
   function loadMore(form) {
     $resource(form.page.next).get(form.page.payload,
       function (data) {

--- a/app/basement/pagination/pagination_service.js
+++ b/app/basement/pagination/pagination_service.js
@@ -11,6 +11,17 @@
  *
  * @returns [Factory]
  */
+
+  /**
+   * paginate
+   *
+   * @method paginate
+   * @desc Add pagination vars for given form
+   *
+   * @param form {Object} Form data for API
+   * @param data {Object} Data response of API
+   * @param payload {Object}
+   */
   function paginate(form, data, payload) {
     form.page = {
       next: data.next,

--- a/app/basement/pagination/pagination_service.js
+++ b/app/basement/pagination/pagination_service.js
@@ -34,6 +34,20 @@
     return form;
   }
 
+  function loadMore(form) {
+    $resource(form.page.next).get(form.page.payload,
+      function (data) {
+        form = paginate(form, data, form.page.payload);
+        $rootScope.$broadcast("gonevisDash.Pagination:loadedMore", {
+          success: true,
+          data: data,
+          page: form.page
+        });
+      }
+    );
+    form.page.loading = true;
+    return form;
+  }
 }
 
 app.factory("Pagination", Pagination);

--- a/app/dolphin/dolphin_controller.js
+++ b/app/dolphin/dolphin_controller.js
@@ -171,6 +171,14 @@ function DolphinController($scope, $rootScope, $state, $stateParams, $mdToast,
     DolphinService.view(dolphin);
   };
 
+  /**
+   * loadMore
+   *
+   * @method loadMore
+   * @desc Load more function for controller
+   */
+  $scope.loadMore = Pagination.loadMore;
+
   $scope.$on("gonevisDash.DolphinService:update", update);
   $scope.$on("gonevisDash.DolphinService:remove", update);
 

--- a/app/dolphin/dolphin_controller.js
+++ b/app/dolphin/dolphin_controller.js
@@ -14,9 +14,10 @@
  * @param ENV
  * @param AuthService
  * @param Upload
+ * @param Pagination
  */
 function DolphinController($scope, $rootScope, $state, $stateParams, $mdToast,
-  DolphinService, Codekit, API, ENV, AuthService, Upload) {
+  DolphinService, Codekit, API, ENV, AuthService, Upload, Pagination) {
 
   var site = AuthService.getCurrentSite();
 
@@ -29,6 +30,7 @@ function DolphinController($scope, $rootScope, $state, $stateParams, $mdToast,
   function constructor() {
     $scope.nothing = { text: "It's lonely here... Try adding some dolphins!" };
     $scope.dolphinService = DolphinService;
+    $scope.dolphinForm = {};
 
     if ($rootScope.selectionMode) {
       $scope.currentTab = "dolphin";
@@ -37,6 +39,9 @@ function DolphinController($scope, $rootScope, $state, $stateParams, $mdToast,
     API.Dolphins.get({},
       function (data) {
         $scope.dolphins = data.results;
+        $scope.dolphinForm = Pagination.paginate(
+          $scope.dolphinForm, data, {}
+        );
       }
     );
 
@@ -184,5 +189,6 @@ DolphinController.$inject = [
   "API",
   "ENV",
   "AuthService",
-  "Upload"
+  "Upload",
+  "Pagination"
 ];

--- a/app/dolphin/dolphin_controller.js
+++ b/app/dolphin/dolphin_controller.js
@@ -174,6 +174,12 @@ function DolphinController($scope, $rootScope, $state, $stateParams, $mdToast,
   $scope.$on("gonevisDash.DolphinService:update", update);
   $scope.$on("gonevisDash.DolphinService:remove", update);
 
+  $scope.$on("gonevisDash.Pagination:loadedMore", function (event, data) {
+    if (!data.success) return;
+    $scope.dolphinForm.page = data.page;
+    $scope.dolphins = $scope.dolphins.concat(data.data.results);
+  });
+
   constructor();
 }
 

--- a/app/dolphin/dolphin_controller.js
+++ b/app/dolphin/dolphin_controller.js
@@ -183,9 +183,10 @@ function DolphinController($scope, $rootScope, $state, $stateParams, $mdToast,
   $scope.$on("gonevisDash.DolphinService:remove", update);
 
   $scope.$on("gonevisDash.Pagination:loadedMore", function (event, data) {
-    if (!data.success) return;
-    $scope.dolphinForm.page = data.page;
-    $scope.dolphins = $scope.dolphins.concat(data.data.results);
+    if (data.success) {
+      $scope.dolphinForm.page = data.page;
+      $scope.dolphins = $scope.dolphins.concat(data.data.results);
+    }
   });
 
   constructor();

--- a/app/dolphin/dolphin_view.html
+++ b/app/dolphin/dolphin_view.html
@@ -25,6 +25,10 @@
           </div>
         </div>
       </div>
+
+      <!-- More -->
+      <ng-include src="'basement/pagination/pagination_loadmore.html'" ng-init="paginationForm = dolphinForm">
+      </ng-include>
     </div>
 
     <!-- Upload -->
@@ -33,7 +37,8 @@
         <div class="panel-heading"><i class="fa fa-fw fa-upload text-info"></i> Upload File</div>
         <div class="panel-body">
           <!-- Select -->
-          <button type="file" class="btn btn-primary" ngf-select="uploadFile($files, $invalidFiles)" ngf-accept="upload.accept" ngf-max-size="25MB" ngf-multiple="true">
+          <button type="file" class="btn btn-primary" ngf-select="uploadFile($files, $invalidFiles)"
+            ngf-accept="upload.accept" ngf-max-size="25MB" ngf-multiple="true">
             <i class="fa fa-fw fa-plus"></i> Select File
           </button>
 

--- a/app/index.html
+++ b/app/index.html
@@ -86,6 +86,7 @@
   <script src="modals/modals_service.js"></script>
 
   <script src="basement/codekit/codekit_service.js"></script>
+  <script src="basement/pagination/pagination_service.js"></script>
 
   <script src="account/auth/auth_interceptor_service.js"></script>
   <script src="account/auth/auth_service.js"></script>

--- a/app/tag/tag_controller.js
+++ b/app/tag/tag_controller.js
@@ -25,13 +25,14 @@ function TagController($scope, $rootScope, $state, $mdToast, TagService, API, Au
   function constructor() {
     $scope.user = AuthService.getAuthenticatedUser();
     $scope.tagService = TagService;
-    $scope.nothing = {
-      text: "It's lonely here... Try adding some tags!"
-    };
+    $scope.tagForm = {};
+    $scope.nothing = { text: "It's lonely here... Try adding some tags!" };
 
-    API.Tags.get({ site: site },
+    var payload = { site: site };
+    API.Tags.get(payload,
       function (data) {
         $scope.tags = data.results;
+        $scope.tagForm = Pagination.paginate($scope.tagForm, data, payload);
       }
     );
   }

--- a/app/tag/tag_controller.js
+++ b/app/tag/tag_controller.js
@@ -11,8 +11,9 @@
  * @param $mdToast
  * @param API
  * @param AuthService
+ * @param Pagination
  */
-function TagController($scope, $rootScope, $state, $mdToast, TagService, API, AuthService) {
+function TagController($scope, $rootScope, $state, $mdToast, TagService, API, AuthService, Pagination) {
 
   var site = AuthService.getCurrentSite();
 
@@ -112,6 +113,12 @@ function TagController($scope, $rootScope, $state, $mdToast, TagService, API, Au
     $scope.tags.unshift(tag);
   });
 
+  $scope.$on("gonevisDash.Pagination:loadedMore", function (event, data) {
+    if (!data.success) return;
+    $scope.tagForm.page = data.page;
+    $scope.tags = $scope.tags.concat(data.data.results);
+  });
+
   constructor();
 }
 
@@ -123,5 +130,6 @@ TagController.$inject = [
   "$mdToast",
   "TagService",
   "API",
-  "AuthService"
+  "AuthService",
+  "Pagination"
 ];

--- a/app/tag/tag_controller.js
+++ b/app/tag/tag_controller.js
@@ -89,6 +89,15 @@ function TagController($scope, $rootScope, $state, $mdToast, TagService, API, Au
   };
 
   $rootScope.$on("gonevisDash.TagService:remove", function (event, data) {
+  /**
+   * loadMore
+   *
+   * @method loadMore
+   * @desc Load more function for controller
+   */
+  $scope.loadMore = Pagination.loadMore;
+
+  $scope.$on("gonevisDash.TagService:remove", function (event, data) {
     for (var i = 0; i < $scope.tags.length; i++) {
       if ($scope.tags[i].id === data.id) {
         $scope.tags[i].isDeleted = true;

--- a/app/tag/tag_controller.js
+++ b/app/tag/tag_controller.js
@@ -89,7 +89,6 @@ function TagController($scope, $rootScope, $state, $mdToast, TagService, API, Au
     );
   };
 
-  $rootScope.$on("gonevisDash.TagService:remove", function (event, data) {
   /**
    * loadMore
    *
@@ -106,7 +105,7 @@ function TagController($scope, $rootScope, $state, $mdToast, TagService, API, Au
     }
   });
 
-  $rootScope.$on("gonevisDash.TagService:create", function (event, data) {
+  $scope.$on("gonevisDash.TagService:create", function (event, data) {
     var tag = data.tag;
     tag.slug = data.data.slug;
     tag.site = data.data.site;

--- a/app/tag/tag_controller.js
+++ b/app/tag/tag_controller.js
@@ -113,9 +113,10 @@ function TagController($scope, $rootScope, $state, $mdToast, TagService, API, Au
   });
 
   $scope.$on("gonevisDash.Pagination:loadedMore", function (event, data) {
-    if (!data.success) return;
-    $scope.tagForm.page = data.page;
-    $scope.tags = $scope.tags.concat(data.data.results);
+    if (data.success) {
+      $scope.tagForm.page = data.page;
+      $scope.tags = $scope.tags.concat(data.data.results);
+    }
   });
 
   constructor();

--- a/app/tag/tag_view.html
+++ b/app/tag/tag_view.html
@@ -40,5 +40,7 @@
         </ul>
       </div>
     </div>
+    <!-- More -->
+    <ng-include src="'basement/pagination/pagination_loadmore.html'" ng-init="paginationForm = tagForm"></ng-include>
   </div>
 </div>


### PR DESCRIPTION
# Pagination
### Usage

- Inject the **Pagination** to controller
- Define a scope var to use its **page** property
- Use that variable after getting the initial items via API using **Pagination.paginate()**
- Include the loadMore template in the view
- Define the form var with **ng-init** attr via **ng-include**
- Define the **loadMore** function for template via **Pagination.loadMore** function
- Watch the **gonevisDash.Pagination:loadedMore** to _concat_ the new data

For examples checkout the pagination at _dolphin_ and _tag_ component.

## Fixes
#87 #90 

## Includes
- Pagination service
- Loadmore include

## Screenshot
![image](https://cloud.githubusercontent.com/assets/4629328/19021257/a7deb76e-88ce-11e6-8ca7-959dac5b4312.png)
