### PR TITLE
Change tab when uploading finished

### DIFF
--- a/app/dolphin/dolphin_controller.js
+++ b/app/dolphin/dolphin_controller.js
@@ -156,6 +156,7 @@ function DolphinController($scope, $rootScope, Dolphin,
                     file.done = true;
                     toaster.success("Upload Complete", file.name);
                     $scope.dolphins.unshift(new Dolphin(data));
+                    $scope.currentTab = "dolphin";
                   }
                 );
               },


### PR DESCRIPTION
…olphin selection
# Bug fixed
Fixes #508 
# Features
When user done uploading files at dolphin selection's file upload tab, when success tab changes to dolphin selection tab. This allows users to get to their needs as soon as possible.