### PR TITLE
Remove gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/SavandBros/gonevis-dash.svg?branch=master)](https://travis-ci.org/SavandBros/gonevis-dash)
 [![codecov](https://codecov.io/gh/SavandBros/gonevis-dash/branch/master/graph/badge.svg)](https://codecov.io/gh/SavandBros/gonevis-dash)
-[![Dependency Status](https://gemnasium.com/badges/github.com/SavandBros/gonevis-dash.svg)](https://gemnasium.com/github.com/SavandBros/gonevis-dash)
 [![Stories in Ready](https://badge.waffle.io/SavandBros/gonevis-dash.png?label=ready&title=Ready)](https://waffle.io/SavandBros/gonevis-dash)
 
 This project is the source code of the [GoNevis Dash](http://dash.gonevis.com), the admin area of of GoNevis blogging platform.


### PR DESCRIPTION
> Why is Gemnasium.com closed? 
> Gemnasium has been acquired by GitLab in January 2018. Since May 15, 2018, the services provided by Gemnasium are no longer available. The team behind Gemnasium has joined GitLab as the new Security Products team and is working on a wider range of tools than just Dependency Scanning: SAST, DAST, Container Scanning and more. If you want to continue monitoring your dependencies, see the Migrating to GitLab section below.

Source: https://docs.gitlab.com/ee/user/project/import/gemnasium.html

![image](https://user-images.githubusercontent.com/4629328/40237931-76425f84-5aba-11e8-8d07-578329c2d1d6.png)

![image](https://user-images.githubusercontent.com/4629328/40237941-7d910fe2-5aba-11e8-9299-acee0b81a38a.png)
