### PR TITLE
Shorter sidebar

### DIFF
--- a/src/style/css/ice.css
+++ b/src/style/css/ice.css
@@ -205,6 +205,12 @@ body {
     height: 32px;
 }
 
+@media (max-height: 645px) {
+    .sidebar-content a:not(.main) {
+        padding: 8px 20px !important;
+    }
+}
+
 
 /* Sidebar button */
 


### PR DESCRIPTION
Fixes #876 

When browser height is short, the sidebar becomes shorter (as much as possible at least).

![image](https://user-images.githubusercontent.com/4629328/41291507-f37f5b8c-6e60-11e8-8c5f-a68e61da9374.png) ![image](https://user-images.githubusercontent.com/4629328/41291488-e0753192-6e60-11e8-8b69-f29990aec376.png) 


