### PR TITLE
Resolve "Remove discord link from main page (it's still in help page)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Fixed #1189: Fix jQuery security vulnerability error.
 - Fixed #1192: Fix toaster for permission error at settings page.
+- Fixed #1194: Remove discord link from main page (it's still in help page).
 
 
 2019.5.1

--- a/src/app/help/help_view.html
+++ b/src/app/help/help_view.html
@@ -4,7 +4,6 @@
   <a class="panel panel-default panel-discord" ng-href="{{ discord }}" target="_blank">
     <div class="panel-body">
       <img src="../../public/img/discord.svg"/>
-      <small class="o-fade"><b class="text-uppercase" translate>NEW</b></small>
       <translate>DISCORD_JOIN</translate>
     </div>
   </a>

--- a/src/app/main/main.css
+++ b/src/app/main/main.css
@@ -26,27 +26,3 @@
     letter-spacing: 2px;
     font-size: 1.5em;
 }
-
-.panel-discord {
-    background: #2c2f33;
-    color: white;
-    font-weight: bold;
-    display: block;
-    cursor: pointer;
-}
-
-.panel-discord:hover,
-.panel-discord:focus {
-    background: #7289da;
-    color: white;
-}
-
-.panel-discord small {
-    margin-right: 2px;
-}
-
-.panel-discord img {
-    float: right;
-    margin: -8px 0 -12px 0;
-    height: 40px;
-}

--- a/src/app/main/main_view.html
+++ b/src/app/main/main_view.html
@@ -30,14 +30,6 @@
           <li translate ng-class="{'o-fade-hard': user.get.location}">SET_LOCATION</li>
         </ul>
       </div>
-      <!-- Discord -->
-      <a class="panel panel-default panel-discord" ng-href="{{ discord }}" target="_blank">
-        <div class="panel-body">
-          <img src="../../public/img/discord.svg"/>
-          <small class="o-fade"><b class="text-uppercase" translate>NEW</b></small>
-          <translate>DISCORD_JOIN</translate>
-        </div>
-      </a>
       <!-- Latest comments -->
       <div class="panel panel-default" ng-if="!Comment.loading">
         <div class="panel-heading">


### PR DESCRIPTION
Fixes #1194 

# Screenshots

![image](https://user-images.githubusercontent.com/15196063/57217132-6fd13700-6ffa-11e9-8226-1cdf5d3456bd.png)

![image](https://user-images.githubusercontent.com/15196063/57217136-73fd5480-6ffa-11e9-9caf-04c2f401676c.png)
